### PR TITLE
Importing CommonModule instead of BrowserModule

### DIFF
--- a/src/t-json-viewer.module.ts
+++ b/src/t-json-viewer.module.ts
@@ -1,8 +1,11 @@
 import {NgModule} from '@angular/core';
+import { CommonModule } from '@angular/common';
 import {TJsonViewerComponent} from './t-json-viewer.component/t-json-viewer.component';
 
 @NgModule({
-  imports: [],
+  imports: [
+    CommonModule
+  ],
   declarations: [
     TJsonViewerComponent
   ],

--- a/src/t-json-viewer.module.ts
+++ b/src/t-json-viewer.module.ts
@@ -1,11 +1,8 @@
 import {NgModule} from '@angular/core';
-import {BrowserModule} from '@angular/platform-browser';
 import {TJsonViewerComponent} from './t-json-viewer.component/t-json-viewer.component';
 
 @NgModule({
-  imports: [
-    BrowserModule
-  ],
+  imports: [],
   declarations: [
     TJsonViewerComponent
   ],

--- a/src/t-json-viewer.module.ts
+++ b/src/t-json-viewer.module.ts
@@ -1,5 +1,5 @@
 import {NgModule} from '@angular/core';
-import { CommonModule } from '@angular/common';
+import {CommonModule} from '@angular/common';
 import {TJsonViewerComponent} from './t-json-viewer.component/t-json-viewer.component';
 
 @NgModule({


### PR DESCRIPTION
BrowserModule should only be imported once in root component of an application.

**Fixes this error:**

> EXCEPTION: Uncaught (in promise): Error: BrowserModule has already been loaded. If you need access to common directives such as NgIf and NgFor from a lazy loaded module, import CommonModule instead.

