### PR TITLE
changing OnChanges to OnInit

### DIFF
--- a/src/t-json-viewer.component/t-json-viewer.component.ts
+++ b/src/t-json-viewer.component/t-json-viewer.component.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 
-import {Component, Input, ViewEncapsulation, OnChanges} from '@angular/core';
+import {Component, Input, ViewEncapsulation, OnInit} from '@angular/core';
 
 interface Item {
   key: string;
@@ -30,9 +30,6 @@ export class TJsonViewerComponent implements OnChanges {
     if (typeof (this.json) !== 'object' && !Array.isArray(this.json)) {
       return;
     }
-
-    // Make the asset array empty again
-    this.asset = [];
 
     /**
      * Convert json to array of items


### PR DESCRIPTION
When using OnChanges and making the asset empty again results that the items are not collapsible anymore.
Due to that, I changed OnChanges to OnInit an removed the empty asset.

Now duplicates stay away and items are collapsible again.