### PR TITLE
Relative paths when importing without bundling

### DIFF
--- a/src/t-json-viewer.component/t-json-viewer.component.ts
+++ b/src/t-json-viewer.component/t-json-viewer.component.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 
-import {Component, Input, ViewEncapsulation, OnChanges} from '@angular/core';
+import {Component, Input, OnChanges} from '@angular/core';
 
-interface Item {
+export interface Item {
   key: string;
   value: any;
   title: string;
@@ -11,10 +11,10 @@ interface Item {
 }
 
 @Component({
+  moduleId: module.id,
   selector: 't-json-viewer',
   templateUrl: './t-json-viewer.component.html',
-  styleUrls: ['./t-json-viewer.component.css'],
-  encapsulation: ViewEncapsulation.None
+  styleUrls: ['./t-json-viewer.component.css']
 })
 export class TJsonViewerComponent implements OnChanges {
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "moduleResolution": "node",
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "removeComments": false,
+        "noImplicitAny": false,
+        "declaration": true,
+        "sourceMap": true,
+        "forceConsistentCasingInFileNames": true,
+        "allowUnreachableCode": false,
+        "noUnusedLocals": true,
+        "noUnusedParameters": false,
+        "noImplicitReturns": true,
+        "allowUnusedLabels": false,
+        "skipLibCheck": true,
+        "lib": [
+            "es5", "dom"
+        ]
+    }
+}


### PR DESCRIPTION
With this PR, it is possible to use this project as a cjs dependency, without the need to bundle or use any other packing process.

This also targets the project to ES5 and generated map files with #30 