### PR TITLE
maxCollapsedLength must be added for array use

### DIFF
--- a/src/t-json-viewer.component/t-json-viewer.component.html
+++ b/src/t-json-viewer.component/t-json-viewer.component.html
@@ -23,7 +23,7 @@
     <div
       class="inner-item"
       *ngIf="item.isOpened && isObject(item)">
-      <t-json-viewer [json]="item.value"></t-json-viewer>
+      <t-json-viewer [json]="item.value" [maxCollapsedLength]="maxCollapsedLength"></t-json-viewer>
     </div>
 
   </div>


### PR DESCRIPTION
When you expand an array, the list of objects will ignore the maxCollapsedLength. So we need to add the maxCollapsedLength also in this view.